### PR TITLE
Other logins block in login.html

### DIFF
--- a/src/unfold/templates/admin/login.html
+++ b/src/unfold/templates/admin/login.html
@@ -70,6 +70,11 @@
                         </button>
                     </div>
                 </form>
+
+                <!-- Allows adding other login buttons e.g. Sign in with Google, etc. -->
+                {% block otherlogins %}
+                    
+                {% endblock %}
             </div>
 
             <div class="absolute flex flex-row items-center justify-between left-0 m-4 right-0 top-0">


### PR DESCRIPTION
Adding a block in the login template so the users can extend the login template and add the logic to add login buttons for other providers e.g. Google, Microsoft, Auth0, etc.

This is required because if the user tries to extend the login template and add the login option as follows 

```
{% extends 'admin/login.html' %}

{% load i18n static socialaccount %}

{% block base %}
{{ block.super }}
<div class="oauth-buttons flex justify-center">
    {% if USE_GOOGLE_ALLAUTH_FOR_ADMIN %}
    <div class="mt-1 w-full sm:w-96">
        <form method="post" action="{% url 'google_login' %}">
            {% csrf_token %}
            <div class="submit-row">
                <button type="submit" class="border flex flex-row font-semibold group items-center justify-center py-2 rounded-md text-sm w-full">
                    <i class="material-symbols-outlined mr-2 relative text-lg transition-all fab fa-google"></i>
                    Sign in with Google
                </button>
            </div>
        </form>
    </div>
    {% endif %}
</div>
{% endblock %}
```

the button is pushed towards the bottom of the page and there's no clean way to put it right below the current login button. See the screenshot below 
<img width="451" alt="image" src="https://github.com/afsangujarati93/django-unfold/assets/32711400/645a02a3-c1a7-442c-9a81-cb288b12365f">

